### PR TITLE
Add moonlight-commit hooks and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # moonlight-commit
+
+**Protect your right to hack after hours.**
+
+`moonlight-commit` is a Git hook system that blocks commits during configurable working hours and days (default 9am–5pm Monday–Friday), with exceptions for hotfix and vacation branches, override commit message flags, and whitelisted GitHub organizations.
+
+## Features
+
+- Configurable block window via Git config
+- Day-of-week filtering (defaults to Mon–Fri)
+- Hotfix and vacation branch exemptions
+- Override flag `[override]` in commit messages
+- GitHub organization whitelist
+
+## Installation
+
+Run the installer for global setup:
+
+```bash
+./install.sh
+```
+
+This copies hooks to `~/.git-hooks` and sets `core.hooksPath` globally.
+
+## Configuration
+
+Customize timings, days, and org whitelist:
+
+```bash
+# Set block hours (inclusive start, exclusive end)
+git config moonlight-commit.blockStart 10
+git config moonlight-commit.blockEnd 16
+
+# Set block days (1=Monday, 7=Sunday)
+git config moonlight-commit.blockDays 1,2,3,4,5
+
+# Whitelist GitHub orgs (comma-separated)
+git config moonlight-commit.whitelistOrgs your-org,another-org
+```
+
+## Branch Exceptions
+
+Branches containing `hotfix` or `vacation` bypass blocking.
+
+## Testing
+
+Automated tests run inside Docker with time and day simulation.
+
+```bash
+docker build -t moonlight-commit-test tests
+docker run --rm moonlight-commit-test
+```
+
+## Website
+
+A minimal static landing page is available at [moonlightcommit.com](https://moonlightcommit.com). The same HTML file (`index.html`) is included in this repo for GitHub Pages hosting.
+
+## License
+
+MIT License
+
+## Credits
+
+Built by indie devs, for indie devs. Inspired by late nights, side hustles, and the eternal right to moonlight.

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,51 @@
+#!/bin/sh
+# moonlight-commit commit-msg hook enforcing override during block window with day filtering and whitelist
+
+# Load configuration with defaults
+BLOCK_START=$(git config --get moonlight-commit.blockStart || echo "9")
+BLOCK_END=$(git config --get moonlight-commit.blockEnd || echo "17")
+BLOCK_DAYS=$(git config --get moonlight-commit.blockDays || echo "1,2,3,4,5")
+WHITELIST_ORGS=$(git config --get moonlight-commit.whitelistOrgs || echo "")
+
+# Get current local hour and day of week
+CURRENT_HOUR=$(date +%H)
+CURRENT_HOUR=${CURRENT_HOUR#0}
+CURRENT_DAY=$(date +%u)
+
+# Get branch name and origin org
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+ORIGIN_URL=$(git remote get-url origin 2>/dev/null || echo "")
+REPO_ORG=$(echo "$ORIGIN_URL" | sed -E 's#.*[:/]{1,2}([^/]+)/.*#\1#')
+
+# Skip checks for hotfix or vacation branches
+echo "$BRANCH_NAME" | grep -qi "hotfix" && exit 0
+echo "$BRANCH_NAME" | grep -qi "vacation" && exit 0
+
+# Skip checks for whitelisted orgs
+for org in ${WHITELIST_ORGS//,/ }; do
+  if [ "$REPO_ORG" = "$org" ]; then exit 0; fi
+done
+
+# Check if current day is in block days
+DAY_ALLOWED=0
+IFS=',' read -r -a DAYS_ARRAY <<< "$BLOCK_DAYS"
+for d in "${DAYS_ARRAY[@]}"; do
+  if [ "$CURRENT_DAY" -eq "$d" ]; then
+    DAY_ALLOWED=1
+    break
+  fi
+done
+
+if [ "$DAY_ALLOWED" -eq 1 ]; then
+  # If within blocked hours, enforce [override] keyword
+  if [ "$CURRENT_HOUR" -ge "$BLOCK_START" ] && [ "$CURRENT_HOUR" -lt "$BLOCK_END" ]; then
+    COMMIT_MSG_FILE="$1"
+    if ! grep -q "\[override\]" "$COMMIT_MSG_FILE"; then
+      FIRST_LINE=$(head -n1 "$COMMIT_MSG_FILE")
+      echo "❌ Commit message '$FIRST_LINE' blocked between ${BLOCK_START}:00 and ${BLOCK_END}:00 on weekdays without [override]." >&2
+      exit 1
+    fi
+  fi
+fi
+
+exit 0

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,58 @@
+#!/bin/sh
+# moonlight-commit pre-commit hook with configurable block window, day filtering, org whitelist, and vacation flag
+
+# Load configuration with defaults
+BLOCK_START=$(git config --get moonlight-commit.blockStart || echo "9")
+BLOCK_END=$(git config --get moonlight-commit.blockEnd || echo "17")
+BLOCK_DAYS=$(git config --get moonlight-commit.blockDays || echo "1,2,3,4,5") # Mon-Fri by default (1=Monday)
+WHITELIST_ORGS=$(git config --get moonlight-commit.whitelistOrgs || echo "")
+
+# Get current local hour (0-23) and day of week (1=Monday, 7=Sunday)
+CURRENT_HOUR=$(date +%H)
+CURRENT_HOUR=${CURRENT_HOUR#0}
+CURRENT_DAY=$(date +%u)
+
+# Get current branch name
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# 1. Hotfix branch exception
+echo "$BRANCH_NAME" | grep -qi "hotfix" && exit 0
+
+# 2. Vacation flag branch exception
+echo "$BRANCH_NAME" | grep -qi "vacation" && exit 0
+
+# 3. Org whitelist exception (parse origin URL)
+ORIGIN_URL=$(git remote get-url origin 2>/dev/null || echo "")
+REPO_ORG=$(echo "$ORIGIN_URL" | sed -E 's#.*[:/]{1,2}([^/]+)/.*#\1#')
+for org in ${WHITELIST_ORGS//,/ }; do
+  if [ "$REPO_ORG" = "$org" ]; then
+    exit 0
+  fi
+done
+
+# 4. Check if current day is in block days
+DAY_ALLOWED=0
+IFS=',' read -r -a DAYS_ARRAY <<< "$BLOCK_DAYS"
+for d in "${DAYS_ARRAY[@]}"; do
+  if [ "$CURRENT_DAY" -eq "$d" ]; then
+    DAY_ALLOWED=1
+    break
+  fi
+done
+
+if [ "$DAY_ALLOWED" -eq 1 ]; then
+  # 5. Time window check: block if CURRENT_HOUR in [BLOCK_START, BLOCK_END)
+  if [ "$CURRENT_HOUR" -ge "$BLOCK_START" ] && [ "$CURRENT_HOUR" -lt "$BLOCK_END" ]; then
+    # Attempt override via commit message (pre-commit only sees COMMIT_EDITMSG if using -m)
+    COMMIT_MSG_FILE=$(git rev-parse --git-path COMMIT_EDITMSG)
+    if [ -f "$COMMIT_MSG_FILE" ] && grep -q "\[override\]" "$COMMIT_MSG_FILE"; then
+      exit 0
+    fi
+    echo "❌ Commit blocked: Commits between ${BLOCK_START}:00 and ${BLOCK_END}:00 on weekdays are disallowed." >&2
+    echo "   Use [override], adjust timings with 'git config moonlight-commit.blockStart/blockEnd/blockDays', or whitelist your org." >&2
+    exit 1
+  fi
+fi
+
+# Otherwise allow commit
+exit 0

--- a/index.html
+++ b/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>moonlight-commit</title>
+  <style>
+    :root {
+      --bg: #0f0f0f;
+      --text: #f0f0f0;
+      --accent: #00ffc3;
+      --muted: #999;
+      --font: 'Segoe UI', sans-serif;
+    }
+    body {
+      margin: 0;
+      font-family: var(--font);
+      background: var(--bg);
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+    header {
+      padding: 2rem 1rem;
+      text-align: center;
+    }
+    header h1 {
+      font-size: 2.5rem;
+      margin: 0;
+      color: var(--accent);
+    }
+    header p {
+      margin-top: 1rem;
+      font-size: 1.2rem;
+      color: var(--muted);
+    }
+    main {
+      flex: 1;
+      padding: 2rem 1rem;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    .features {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1.5rem;
+      margin-top: 2rem;
+    }
+    .feature {
+      background: #1a1a1a;
+      padding: 1rem;
+      border-radius: 8px;
+      border: 1px solid #222;
+    }
+    .feature h3 {
+      margin-top: 0;
+      color: var(--accent);
+    }
+    footer {
+      text-align: center;
+      padding: 1rem;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    @media (max-width: 600px) {
+      header h1 {
+        font-size: 2rem;
+      }
+      header p {
+        font-size: 1rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>moonlight-commit</h1>
+    <p>Protect your right to hack after hours.</p>
+  </header>
+  <main>
+    <p>
+      <strong>moonlight-commit</strong> is a Git hook that blocks commits during work hours (default 9am–5pm Monday–Friday), helping you preserve your creative energy for personal projects. Inspired by California Labor Code §2870, it ensures your side projects stay yours.
+    </p>
+    <div class="features">
+      <div class="feature">
+        <h3>🕒 Configurable Hours & Days</h3>
+        <p>Set your own block window and days via <code>git config</code>.</p>
+      </div>
+      <div class="feature">
+        <h3>🚨 Hotfix & Vacation Exemption</h3>
+        <p>Commits on <code>hotfix/*</code> or <code>vacation/*</code> branches always go through.</p>
+      </div>
+      <div class="feature">
+        <h3>🏢 Org Whitelist</h3>
+        <p>Never block commits to whitelisted GitHub organizations.</p>
+      </div>
+      <div class="feature">
+        <h3>🔓 Override Flag</h3>
+        <p>Use <code>[override]</code> in commit messages to bypass restrictions.</p>
+      </div>
+    </div>
+    <p style="margin-top:2rem;">
+      View the project on <a href="https://github.com/YOUR_USERNAME/moonlight-commit" target="_blank" rel="noopener noreferrer">GitHub</a>.
+    </p>
+  </main>
+  <footer>
+    &copy; 2025 moonlight-commit · <a href="https://moonlightcommit.com">moonlightcommit.com</a>
+  </footer>
+</body>
+</html>

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# moonlight-commit installer - installs hooks globally with executable permissions and configures core.hooksPath
+
+set -e
+
+echo "Installing moonlight-commit hooks globally..."
+
+mkdir -p ~/.git-hooks
+
+cp hooks/pre-commit ~/.git-hooks/pre-commit
+cp hooks/commit-msg ~/.git-hooks/commit-msg
+
+chmod +x ~/.git-hooks/pre-commit
+chmod +x ~/.git-hooks/commit-msg
+
+git config --global core.hooksPath ~/.git-hooks
+
+echo "✅ moonlight-commit installed globally!"
+echo "🌙 Hack freely after hours."

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      git \
+      bash \
+      libfaketime \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+COPY hooks/ ./hooks/
+RUN chmod +x hooks/pre-commit hooks/commit-msg
+
+COPY tests/run-tests.sh /usr/local/bin/run-tests.sh
+RUN chmod +x /usr/local/bin/run-tests.sh
+
+ENTRYPOINT ["run-tests.sh"]

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# helper function to run commit at a given faketime and branch with message
+# outputs result
+
+test_commit() {
+  local faketime="$1"
+  local msg="$2"
+  local branch="$3"
+  echo -n "→ Testing at $faketime on branch '$branch' with message \"$msg\" ... "
+  rm -rf /tmp/repo && mkdir -p /tmp/repo
+  cd /tmp/repo
+  git init -q
+  git config core.hooksPath /usr/src/app/hooks
+  echo "# $$" > README.md
+  git add README.md
+  git commit -q -m "init"
+  git checkout -b "$branch"
+  echo "change" >> README.md
+  git add README.md
+
+  if faketime -f "$faketime" git commit -q -m "$msg"; then
+    echo "✅"
+    return 0
+  else
+    echo "❌"
+    return 1
+  fi
+}
+
+echo
+echo "🧪 moonlight-commit automated tests"
+echo "-----------------------------------"
+
+# 1) During working hours Mon-Fri → should be blocked
+# 2025-04-30 is Wednesday
+if test_commit "2025-04-30 10:15:00" "feature during hours" "feature/main"; then
+  echo "✗ Should have been blocked"; exit 1
+else
+  echo "✓ Blocked as expected"
+fi
+
+# 2) Override keyword during hours → allowed
+if test_commit "2025-04-30 14:00:00" "hotfix-x [override]" "feature/main"; then
+  echo "✓ Override works"
+else
+  echo "✗ Should have been allowed"; exit 1
+fi
+
+# 3) On hotfix branch during hours → allowed
+if test_commit "2025-04-30 11:00:00" "fix bug" "hotfix/urgent"; then
+  echo "✓ Hotfix branch pass-through"
+else
+  echo "✗ Hotfix branch should pass"; exit 1
+fi
+
+# 4) On vacation branch during hours → allowed
+if test_commit "2025-04-30 11:00:00" "vacation day commit" "vacation/dayoff"; then
+  echo "✓ Vacation branch pass-through"
+else
+  echo "✗ Vacation branch should pass"; exit 1
+fi
+
+# 5) Weekend commit during blocked hours → allowed (Sat=6)
+if test_commit "2025-05-03 10:00:00" "weekend commit" "feature/weekend"; then
+  echo "✓ Weekend commit allowed"
+else
+  echo "✗ Weekend commit should pass"; exit 1
+fi
+
+# 6) After hours commit → allowed
+if test_commit "2025-04-30 20:30:00" "feature at night" "feature/main"; then
+  echo "✓ After-hours commit allowed"
+else
+  echo "✗ Should have been allowed"; exit 1
+fi
+
+# 7) Whitelisted org bypass
+mkdir -p /tmp/repo && cd /tmp/repo
+git init -q
+git config core.hooksPath /usr/src/app/hooks
+git config moonlight-commit.whitelistOrgs "myorg"
+# prepare repo
+echo "# test" > README.md
+git add README.md
+git commit -q -m "init"
+git remote add origin git@github.com:myorg/repo.git
+
+# commit during working hours should succeed
+git checkout -b feature/main
+echo "change" >> README.md
+git add README.md
+if faketime -f "2025-04-30 10:00:00" git commit -q -m "commit during hours"; then
+  echo "✓ Whitelisted org bypass works"
+else
+  echo "✗ Whitelisted org commit blocked"; exit 1
+fi
+
+echo
+echo "🎉 All tests passed!"


### PR DESCRIPTION
## Summary
- implement configurable pre-commit and commit-msg hooks
- add installer script
- include static landing page and README docs
- add docker-based tests

## Testing
- `docker build -t moonlight-commit-test tests` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683aefa99bfc83238750bb3a6ee66a74

## Summary by Sourcery

Implement configurable Git hooks that block commits during work hours with branch and message overrides, add a global installer, documentation, a static landing page, and Docker-based tests.

New Features:
- Add Git pre-commit and commit-msg hooks to enforce configurable work-hour commit restrictions
- Implement an installer script for global hook setup

Enhancements:
- Include a static landing page (index.html) for GitHub Pages hosting

Build:
- Add a Dockerfile to build the test environment

Documentation:
- Expand README with detailed usage, configuration, installation, testing, and website information

Tests:
- Introduce a Docker-based automated test script to simulate commit times and validate hook behavior