### PR TITLE
Improve installer and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,18 @@ Run the installer for global setup:
 ./install.sh
 ```
 
-This copies hooks to `~/.git-hooks` and sets `core.hooksPath` globally.
+This copies hooks to `~/.git-hooks` and sets `core.hooksPath` globally. If you already
+have a global hooks directory configured, the installer will prompt to back it up
+before overriding. To remove the hooks and restore the previous configuration, run
+`./install.sh --uninstall`.
+
+## Uninstall
+
+To remove moonlight-commit and restore your previous `core.hooksPath` value, run:
+
+```bash
+./install.sh --uninstall
+```
 
 ## Configuration
 
@@ -53,7 +64,7 @@ docker run --rm moonlight-commit-test
 
 ## Website
 
-A minimal static landing page is available at [moonlightcommit.com](https://moonlightcommit.com). The same HTML file (`index.html`) is included in this repo for GitHub Pages hosting.
+A minimal static landing page is available at [moonlightcommit.com](https://moonlightcommit.com). The same HTML file (`index.html`) is included in this repo for GitHub Pages hosting. The GitHub link on the page is populated by a small script. If you host the page on a custom domain, edit the `data-repo-owner` attribute in the script tag to point to your GitHub username so the link resolves correctly.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       --text: #f0f0f0;
       --accent: #00ffc3;
       --muted: #999;
-      --font: 'Segoe UI', sans-serif;
+      --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     }
     body {
       margin: 0;
@@ -89,7 +89,8 @@
     <p>
       <strong>moonlight-commit</strong> is a Git hook that blocks commits during work hours (default 9am–5pm Monday–Friday), helping you preserve your creative energy for personal projects. Inspired by California Labor Code §2870, it ensures your side projects stay yours.
     </p>
-    <div class="features">
+    <h2 id="features">Features</h2>
+    <div class="features" aria-labelledby="features">
       <div class="feature">
         <h3>🕒 Configurable Hours & Days</h3>
         <p>Set your own block window and days via <code>git config</code>.</p>
@@ -107,9 +108,23 @@
         <p>Use <code>[override]</code> in commit messages to bypass restrictions.</p>
       </div>
     </div>
-    <p style="margin-top:2rem;">
-      View the project on <a href="https://github.com/YOUR_USERNAME/moonlight-commit" target="_blank" rel="noopener noreferrer">GitHub</a>.
+    <p id="github-paragraph" style="margin-top:2rem;">
+      View the project on <a id="github-link" href="#" target="_blank" rel="noopener noreferrer">GitHub</a>.
     </p>
+    <script data-repo-owner="YOUR_USERNAME">
+      (function() {
+        var owner = document.currentScript.getAttribute('data-repo-owner');
+        if (!owner) {
+          var host = location.hostname;
+          if (host.endsWith('.github.io')) {
+            owner = host.replace('.github.io', '');
+          }
+        }
+        if (owner) {
+          document.getElementById('github-link').href = 'https://github.com/' + owner + '/moonlight-commit';
+        }
+      })();
+    </script>
   </main>
   <footer>
     &copy; 2025 moonlight-commit · <a href="https://moonlightcommit.com">moonlightcommit.com</a>

--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,59 @@
-#!/bin/bash
-# moonlight-commit installer - installs hooks globally with executable permissions and configures core.hooksPath
+#!/usr/bin/env bash
+# moonlight-commit installer - installs hooks globally with executable permissions
+# Passing --uninstall restores the previous hooksPath if recorded
 
-set -e
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS_DIR="$HOME/.git-hooks"
+BACKUP_FILE="$HOOKS_DIR.previous"
+
+if [[ "${1:-}" == "--uninstall" ]]; then
+  if [ -f "$BACKUP_FILE" ]; then
+    PREV=$(cat "$BACKUP_FILE")
+    if [ -n "$PREV" ]; then
+      git config --global core.hooksPath "$PREV"
+      echo "Restored core.hooksPath to $PREV"
+    else
+      git config --global --unset core.hooksPath
+      echo "Removed core.hooksPath setting"
+    fi
+    rm -f "$BACKUP_FILE"
+    echo "moonlight-commit uninstalled."
+  else
+    echo "moonlight-commit was not installed." >&2
+  fi
+  exit 0
+fi
 
 echo "Installing moonlight-commit hooks globally..."
 
-mkdir -p ~/.git-hooks
+EXISTING=$(git config --global --get core.hooksPath || true)
+if [ -n "$EXISTING" ] && [ "$EXISTING" != "$HOOKS_DIR" ]; then
+  echo "Existing global hooks found at '$EXISTING'."
+  read -r -p "Back up and override with moonlight-commit? [y/N] " resp
+  if [[ "$resp" =~ ^[Yy]$ ]]; then
+    BACKUP_DIR="$EXISTING.backup.$(date +%s)"
+    mkdir -p "$BACKUP_DIR"
+    cp -r "$EXISTING"/* "$BACKUP_DIR" 2>/dev/null || true
+    echo "Backed up existing hooks to $BACKUP_DIR"
+    echo "$EXISTING" > "$BACKUP_FILE"
+  else
+    echo "Aborting installation."
+    exit 1
+  fi
+else
+  : > "$BACKUP_FILE"
+fi
 
-cp hooks/pre-commit ~/.git-hooks/pre-commit
-cp hooks/commit-msg ~/.git-hooks/commit-msg
+mkdir -p "$HOOKS_DIR"
 
-chmod +x ~/.git-hooks/pre-commit
-chmod +x ~/.git-hooks/commit-msg
+cp "$DIR/hooks/pre-commit" "$HOOKS_DIR/pre-commit"
+cp "$DIR/hooks/commit-msg" "$HOOKS_DIR/commit-msg"
 
-git config --global core.hooksPath ~/.git-hooks
+chmod +x "$HOOKS_DIR/pre-commit" "$HOOKS_DIR/commit-msg"
+
+git config --global core.hooksPath "$HOOKS_DIR"
 
 echo "✅ moonlight-commit installed globally!"
-echo "🌙 Hack freely after hours."
+echo "Run './install.sh --uninstall' to restore previous settings."


### PR DESCRIPTION
## Summary
- improve index page font stack and accessibility heading
- add script to populate GitHub link automatically
- warn and backup existing hooks path in install.sh, add uninstall option and portable shebang
- expand README with uninstall docs and note on GitHub link customization

## Testing
- `bash tests/run-tests.sh` *(fails: faketime not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b697a9d188323a565ecd41fc5721a

## Summary by Sourcery

Enhance the installer with backup, override prompts, strict mode, and an uninstall option; improve landing page styling and accessibility; and expand documentation with uninstall and link-customization instructions.

New Features:
- Add `--uninstall` option to the installer to restore or remove the previous `core.hooksPath` setting
- Prompt to back up and override an existing global hooks directory during installation
- Populate the GitHub link on the landing page dynamically via a small script based on `data-repo-owner` or GitHub Pages hostname

Enhancements:
- Switch installer to a portable `#!/usr/bin/env bash` shebang with `set -euo pipefail` for stricter error handling
- Improve landing page font stack and add an accessible heading for the Features section
- Update installer messages to include uninstall instructions

Documentation:
- Expand README to document the uninstall process and GitHub link customization for custom domains