### PR TITLE
Reject empty whitelist org entries

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -75,6 +75,27 @@ validate_config() {
     IFS=,
   done
   IFS=$old_ifs
+
+  if [ -n "$WHITELIST_ORGS" ]; then
+    case "$WHITELIST_ORGS" in
+      *,,*|,*|*,)
+        echo "❌ moonlight-commit.whitelistOrgs must not contain empty entries" >&2
+        exit 1
+        ;;
+    esac
+    old_ifs=$IFS
+    IFS=,
+    for org in $WHITELIST_ORGS; do
+      IFS=$old_ifs
+      org=$(printf '%s' "$org" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      if [ -z "$org" ]; then
+        echo "❌ moonlight-commit.whitelistOrgs must not contain empty entries" >&2
+        exit 1
+      fi
+      IFS=,
+    done
+    IFS=$old_ifs
+  fi
 }
 
 validate_config

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -90,6 +90,27 @@ validate_config() {
     IFS=,
   done
   IFS=$old_ifs
+
+  if [ -n "$WHITELIST_ORGS" ]; then
+    case "$WHITELIST_ORGS" in
+      *,,*|,*|*,)
+        echo "❌ moonlight-commit.whitelistOrgs must not contain empty entries" >&2
+        exit 1
+        ;;
+    esac
+    old_ifs=$IFS
+    IFS=,
+    for org in $WHITELIST_ORGS; do
+      IFS=$old_ifs
+      org=$(printf '%s' "$org" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      if [ -z "$org" ]; then
+        echo "❌ moonlight-commit.whitelistOrgs must not contain empty entries" >&2
+        exit 1
+      fi
+      IFS=,
+    done
+    IFS=$old_ifs
+  fi
 }
 
 validate_config

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -193,6 +193,29 @@ test_hooks_reject_empty_day_entries() {
   echo "✅"
 }
 
+test_hooks_reject_empty_whitelist_org_entries() {
+  echo -n "→ Testing hooks reject empty whitelist org entries ... "
+  rm -rf /tmp/repo && mkdir -p /tmp/repo
+  cd /tmp/repo
+  git init -q
+  git config core.hooksPath /usr/src/app/hooks
+  echo "# empty whitelist entries" > README.md
+  git add README.md
+  git commit --no-verify -q -m "init"
+  git checkout -q -b feature/empty-whitelist
+  echo "change" >> README.md
+  git add README.md
+
+  if MOONLIGHT_WHITELIST_ORGS='myorg,,other' faketime -f "2025-04-30 10:15:00" git commit -q -m "empty whitelist config" >/tmp/moonlight-empty-whitelist.log 2>&1; then
+    echo "❌"
+    echo "Empty whitelist org entries should have failed"; exit 1
+  fi
+
+  grep -q "moonlight-commit.whitelistOrgs must not contain empty entries" /tmp/moonlight-empty-whitelist.log
+
+  echo "✅"
+}
+
 test_pre_commit_rejects_unknown_args() {
   echo -n "→ Testing pre-commit rejects unknown arguments ... "
   rm -rf /tmp/repo && mkdir -p /tmp/repo
@@ -385,6 +408,7 @@ test_installer_cleans_downloaded_hooks_from_custom_tmpdir
 test_rejects_invalid_block_window_config
 test_commit_msg_rejects_invalid_day_config
 test_hooks_reject_empty_day_entries
+test_hooks_reject_empty_whitelist_org_entries
 test_pre_commit_rejects_unknown_args
 test_pre_commit_rejects_extra_args
 test_commit_msg_rejects_missing_args


### PR DESCRIPTION
## Summary
- reject malformed `moonlight-commit.whitelistOrgs` CSV values with empty entries
- apply the validation in both `pre-commit` and `commit-msg` hooks
- add Docker harness coverage for the malformed whitelist case

## Verification
- sh -n hooks/pre-commit hooks/commit-msg install.sh && bash -n tests/run-tests.sh
- docker build -f tests/Dockerfile -t moonlight-commit-tests . && docker run --rm moonlight-commit-tests

## Notes
- Preserved unrelated untracked `GOAL.md` and `KANBAN.md` files locally.

## Summary by Sourcery

Validate whitelist organization configuration in Git hooks and add coverage for malformed entries.

Bug Fixes:
- Reject commits when moonlight-commit.whitelistOrgs contains empty CSV entries in pre-commit and commit-msg hooks.

Tests:
- Add Docker-based test ensuring hooks fail when whitelist org configuration includes empty entries and integrate it into the test suite.