### PR TITLE
Reject missing commit-msg files

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -10,6 +10,11 @@ if [ "$#" -ne 1 ]; then
   exit 2
 fi
 
+if [ ! -f "$1" ]; then
+  echo "commit-msg file must exist: $1" >&2
+  exit 2
+fi
+
 # Load configuration with defaults. Environment variables override git config.
 BLOCK_START="${MOONLIGHT_BLOCK_START:-$(git config --get moonlight-commit.blockStart 2>/dev/null)}"
 [ -z "$BLOCK_START" ] && BLOCK_START=9

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -284,6 +284,38 @@ test_commit_msg_rejects_missing_args() {
   echo "✅"
 }
 
+test_commit_msg_rejects_missing_message_file() {
+  echo -n "→ Testing commit-msg rejects missing message file path ... "
+  rm -rf /tmp/repo && mkdir -p /tmp/repo
+  cd /tmp/repo
+  git init -q
+
+  if /usr/src/app/hooks/commit-msg /tmp/moonlight-missing-message >/tmp/moonlight-commit-msg-missing-file.log 2>&1; then
+    echo "❌"
+    echo "commit-msg should reject missing message files"; exit 1
+  fi
+
+  grep -q "commit-msg file must exist: /tmp/moonlight-missing-message" /tmp/moonlight-commit-msg-missing-file.log
+
+  echo "✅"
+}
+
+test_commit_msg_rejects_message_directory() {
+  echo -n "→ Testing commit-msg rejects message directory paths ... "
+  rm -rf /tmp/repo /tmp/moonlight-message-dir && mkdir -p /tmp/repo /tmp/moonlight-message-dir
+  cd /tmp/repo
+  git init -q
+
+  if /usr/src/app/hooks/commit-msg /tmp/moonlight-message-dir >/tmp/moonlight-commit-msg-dir.log 2>&1; then
+    echo "❌"
+    echo "commit-msg should reject directory message paths"; exit 1
+  fi
+
+  grep -q "commit-msg file must exist: /tmp/moonlight-message-dir" /tmp/moonlight-commit-msg-dir.log
+
+  echo "✅"
+}
+
 test_commit_msg_rejects_extra_args() {
   echo -n "→ Testing commit-msg rejects extra arguments ... "
   rm -rf /tmp/repo && mkdir -p /tmp/repo
@@ -431,6 +463,8 @@ test_hooks_reject_empty_whitelist_org_entries
 test_pre_commit_rejects_unknown_args
 test_pre_commit_rejects_extra_args
 test_commit_msg_rejects_missing_args
+test_commit_msg_rejects_missing_message_file
+test_commit_msg_rejects_message_directory
 test_commit_msg_rejects_extra_args
 test_pre_commit_defers_to_relative_hooks_path_commit_msg_from_subdir
 


### PR DESCRIPTION
## Summary
- reject missing or directory commit-msg hook arguments before config/time checks
- add Docker harness coverage for missing message file paths and directory paths

## Validation
- sh -n hooks/commit-msg hooks/pre-commit install.sh
- bash -n tests/run-tests.sh
- docker build -f tests/Dockerfile -t moonlight-commit-test . && docker run --rm moonlight-commit-test
- git diff --check

## Notes
- left existing untracked GOAL.md and KANBAN.md untouched

## Summary by Sourcery

Tighten commit-msg hook validation around commit message file paths and expand test coverage for these failure cases.

Tests:
- Add tests ensuring the commit-msg hook rejects missing commit message files.
- Add tests ensuring the commit-msg hook rejects directory paths passed as commit message files.